### PR TITLE
Use docker for developing and running SyPet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Development environment with ant and java 8.
+FROM frekele/ant:1.10.3-jdk8 AS dev
+WORKDIR /app
+CMD ["/bin/bash"]
+
+# Build SyPet in the development environment.
+FROM dev AS build
+WORKDIR /app
+COPY . .
+RUN ant jar
+
+# Run SyPet as a docker app.
+FROM frekele/java:jdk8u172 AS app
+WORKDIR /app
+COPY --from=build /app/sypet.jar ./
+COPY --from=build /app/lib ./lib
+ENTRYPOINT ["java", "-cp", "sypet.jar:lib/sat4j-pb.jar:lib/apt.jar:lib/commons-lang3-3.4.jar:lib/gson-2.8.5.jar:lib/point.jar:lib/soot-trunk.jar:lib/systring.jar", "cmu.edu.ui.SyPet"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+# Build docker image for the development environment.
+build-dev:
+	docker build -t sypet-dev-img --target dev .
+
+# Create docker container for the development environment.
+create-dev:
+	docker create -it \
+	--name sypet-dev \
+	--mount type=bind,source=$(PWD),target=/app \
+	sypet-dev-img
+
+# Start docker container for the development environment.
+start-dev:
+	docker start -ai sypet-dev
+
+# Stop docker container for the development environment.
+stop-dev:
+	docker stop sypet-dev
+
+# Build docker image for the SyPet app.
+build-app:
+	docker build -t sypet-app-img --target app .
+
+# Run SyPet as a docker app. Usage is `make run-app FILE=<filename>`, where
+# <filename> is the argument to SyPet.
+run-app:
+	docker run --rm \
+	--mount type=bind,\
+	source=$(shell dirname $(PWD)/$(FILE)),\
+	target=/app/$(shell dirname $(FILE)),\
+	readonly \
+	sypet-app-img $(FILE)
+
+clean:
+	docker container rm sypet-dev
+
+veryclean: clean
+	docker image rm sypet-dev-img
+	docker image rm sypet-app-img
+
+.PHONY: build-dev create-dev start stop \
+	build-app run-app \
+	clean veryclean

--- a/README.md
+++ b/README.md
@@ -57,13 +57,11 @@ make stop-dev   # Stop docker container
 
 ## Running SyPet
 
-Having built SyPet, you can the run it with Ant:
+Having built SyPet, you can then run it with Ant:
 
 ```
 ant sypet -Dargs=path/to/input/file
 ```
-
-For example:
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Component-Based Synthesis for Complex APIs. POPL 2017.
 Yu Feng, Ruben Martins, Yuepeng Wang, Isil Dillig, Thomas W. Reps. 
 ```
 
+### Features
+
 Version 2.0 of SyPet has the following additional features (some under development):
 * Atom plug-in for increased usability;
 * Use of program analysis to prune equivalent infeasible programs;
@@ -25,6 +27,57 @@ More details about SyPet can be found at:
 * Webpage: https://utopia-group.github.io/sypet/
 * GitHub SyPet 1.0: https://github.com/utopia-group/sypet
 
-# Acknowledgments
+## Building SyPet from Source
+
+SyPet has been tested on Linux and Mac OS environments.
+
+Prerequisites for building SyPet:
+
+* Java 8 (More recent versions are not yet supported)
+* Ant (We are currently using version 1.10)
+
+```
+git clone https://github.com/sat-group/sypet.git
+cd sypet
+ant clean jar
+```
+
+### Docker
+
+You can use docker to set up a development environment with the prerequisites
+pre-installed. The provided Makefile lets you build the image, and to create,
+start and stop the container:
+
+```
+make build-dev  # Build docker image
+make create-dev # Create docker container
+make start-dev  # Start docker container
+make stop-dev   # Stop docker container
+```
+
+## Running SyPet
+
+Having built SyPet, you can the run it with Ant:
+
+```
+ant sypet -Dargs=path/to/input/file
+```
+
+For example:
+
+### Docker
+
+Alternatively, you can run SyPet as a docker app:
+
+```
+# Build docker image for the SyPet app
+make build-app
+
+# Run as a docker app. <filename> is the argument to SyPet
+make run-app FILE=<filename>
+```
+
+## Acknowledgments
 
 SyPet 2.0 is mainly developed and maintained by Ruben Martins at CMU. We would like to thank the UToPiA research group lead by Isil Dillig at UT Austin and Yu Feng at UCSB (former PhD student at UT Austin) for their collaboration in this project. We would also like to thank all contributors to this project, namely, Yuepeng Wang at UT Austin, Tom Reps at UW-Madison and Kaige Liu, Anlun Xu, Tianlei Pan and Mayank Jain at CMU.
+


### PR DESCRIPTION
Added a Dockerfile that permits creating a docker container set up with a
development environment for SyPet. It is also possible to run SyPet from docker.

Added a Makefile that permits doing that without needing to type large commands.

The README.md was also updated with information about how to build and run
SyPet, with or without docker.